### PR TITLE
prefer nerdctl over crictl for containerd if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ If desired pod is still initializing, nsenter will pick currently running contai
 Container Runtimes Clients:
 
 - docker;
-- crictl.
+- crictl - expected to be present on nodes with cri-o runtime;
+- nerdctl - expected to be present on nodes with containerd runtime; crictl will be used as a fallback.
 
 OS:
 

--- a/internal/containerinfo/containerinfo.go
+++ b/internal/containerinfo/containerinfo.go
@@ -10,6 +10,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+const containerdShellCmd = `"if command -v nerdctl >/dev/null 2>&1; then
+	exec nerdctl inspect %[1]s --format {{.State.Pid}}
+fi
+exec crictl inspect --output go-template --template={{.info.pid}} %[1]s"`
+
 type ContainerInfo struct {
 	NodeName         string
 	NodeIP           string
@@ -90,11 +95,6 @@ func getContainerStatus(pod *v1.Pod, cfg *config.Config) (*v1.ContainerStatus, e
 	return nil, fmt.Errorf("pod %v has no running containers", pod.Name)
 }
 
-const containerdShellCmd = `"if command -v nerdctl >/dev/null 2>&1; then
-	exec nerdctl inspect %[1]s --format {{.State.Pid}}
-fi
-exec crictl inspect --output go-template --template={{.info.pid}} %[1]s"`
-
 func GetPidDiscoverCommand(containerInfo *ContainerInfo) ([]string, error) {
 	switch containerInfo.ContainerRuntime {
 	case "docker":
@@ -108,7 +108,12 @@ func GetPidDiscoverCommand(containerInfo *ContainerInfo) ([]string, error) {
 		}, nil
 
 	case "containerd":
-		return []string{"sudo", "sh", "-c", fmt.Sprintf(containerdShellCmd, containerInfo.ContainerID)}, nil
+		return []string{
+			"sudo",
+			"sh",
+			"-c",
+			fmt.Sprintf(containerdShellCmd, containerInfo.ContainerID),
+		}, nil
 
 	case "cri-o":
 		return []string{


### PR DESCRIPTION
Many thanks for this useful tool.

We prefer to use containerd's native `nerdctl` CLI tool over `crictl` which isn't even available on the k8s hosts.

This PR will use it if available and fallback to `crictl` otherwise.

Tested on our k0s cluster.

Could you please take a look?