### PR TITLE
chore(workflows): switch to goreleaser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/build-by-commit.yml
+++ b/.github/workflows/build-by-commit.yml
@@ -31,8 +31,14 @@ jobs:
         with:
           args: --timeout=3m
 
-      - name: Install dependencies
-        run: go mod download
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: v2.9.0
+          install-only: true
 
       - name: Verify build
-        run: make dev
+        shell: bash
+        run: |
+          goreleaser check
+          ARTIFACT_VERSION="local" goreleaser build --clean --snapshot

--- a/.github/workflows/build-by-commit.yml
+++ b/.github/workflows/build-by-commit.yml
@@ -3,11 +3,11 @@ name: build by commit
 on:
   push:
     branches:
-    - '*'
+      - "*"
 
   pull_request:
     branches:
-    - '*'
+      - "*"
 
 env:
   ARTIFACT_VERSION: ${{ github.ref_name }}
@@ -16,23 +16,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.23.2'
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.2"
 
-    - name: Verify go.mod is sane
-      run: go mod tidy && git diff --no-patch --exit-code
+      - name: Verify go.mod is sane
+        run: go mod tidy && git diff --no-patch --exit-code
 
-    - name: Run code lint
-      uses: golangci/golangci-lint-action@v3.7.0
-      with:
-        args: --timeout=3m
+      - name: Run code lint
+        uses: golangci/golangci-lint-action@v3.7.0
+        with:
+          args: --timeout=3m
 
-    - name: Install dependencies
-      run: go mod download
+      - name: Install dependencies
+        run: go mod download
 
-    - name: Verify build
-      run: make dev
+      - name: Verify build
+        run: make dev

--- a/.github/workflows/build-by-commit.yml
+++ b/.github/workflows/build-by-commit.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.2"
+          go-version-file: go.mod
 
       - name: Verify go.mod is sane
         run: go mod tidy && git diff --no-patch --exit-code

--- a/.github/workflows/build-by-tag.yml
+++ b/.github/workflows/build-by-tag.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   ARTIFACT_VERSION: ${{ github.ref_name }}
-  GO111MODULE: "on"
 
 jobs:
   build:

--- a/.github/workflows/build-by-tag.yml
+++ b/.github/workflows/build-by-tag.yml
@@ -35,13 +35,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # krew:
-  #   needs:
-  #     - build
-  #   runs-on: ubuntu-latest
+  krew:
+    needs:
+      - build
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Update new version in krew-index
-  #       uses: rajatjindal/krew-release-bot@v0.0.46
+      - name: Update new version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.github/workflows/build-by-tag.yml
+++ b/.github/workflows/build-by-tag.yml
@@ -32,13 +32,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  krew:
-    needs:
-      - build
-    runs-on: ubuntu-latest
+  # krew:
+  #   needs:
+  #     - build
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Update new version in krew-index
-        uses: rajatjindal/krew-release-bot@v0.0.46
+  #     - name: Update new version in krew-index
+  #       uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.github/workflows/build-by-tag.yml
+++ b/.github/workflows/build-by-tag.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.2"
+          go-version-file: go.mod
 
       - name: Verify go.mod is sane
         run: go mod tidy && git diff --no-patch --exit-code

--- a/.github/workflows/build-by-tag.yml
+++ b/.github/workflows/build-by-tag.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - run: |
+          go mod tidy
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/build-by-tag.yml
+++ b/.github/workflows/build-by-tag.yml
@@ -5,59 +5,36 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  contents: write
+
 env:
   ARTIFACT_VERSION: ${{ github.ref_name }}
 
 jobs:
   build:
-    strategy:
-      matrix:
-        goos: ["linux", "darwin"]
-        goarch: ["amd64", "arm64"]
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
-      - name: Verify go.mod is sane
-        run: go mod tidy && git diff --no-patch --exit-code
-
-      - name: Run code lint
-        uses: golangci/golangci-lint-action@v6.0.1
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          args: --timeout=3m
-
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Verify build
-        run: make dev
-
-      - name: Make binaries
-        run: |
-          set -euo pipefail
-          sudo apt update
-          sudo apt install -y upx
-          make ${{ matrix.goos }}/${{ matrix.goarch }}/archive
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
+          version: v2.9.0
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: false
-          files: out/*
 
   krew:
-    needs: build
+    needs:
+      - build
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-by-tag.yml
+++ b/.github/workflows/build-by-tag.yml
@@ -3,14 +3,13 @@ name: build by tag
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 env:
   ARTIFACT_VERSION: ${{ github.ref_name }}
-  GO111MODULE: 'on'
+  GO111MODULE: "on"
 
 jobs:
-
   build:
     strategy:
       matrix:
@@ -19,50 +18,51 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.23.2'
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.2"
 
-    - name: Verify go.mod is sane
-      run: go mod tidy && git diff --no-patch --exit-code
+      - name: Verify go.mod is sane
+        run: go mod tidy && git diff --no-patch --exit-code
 
-    - name: Run code lint
-      uses: golangci/golangci-lint-action@v6.0.1
-      with:
-        args: --timeout=3m
+      - name: Run code lint
+        uses: golangci/golangci-lint-action@v6.0.1
+        with:
+          args: --timeout=3m
 
-    - name: Install dependencies
-      run: go mod download
+      - name: Install dependencies
+        run: go mod download
 
-    - name: Verify build
-      run: make dev
+      - name: Verify build
+        run: make dev
 
-    - name: Make binaries
-      run: |
-        set -euo pipefail
-        sudo apt update
-        sudo apt install -y upx
-        make ${{ matrix.goos }}/${{ matrix.goarch }}/archive
+      - name: Make binaries
+        run: |
+          set -euo pipefail
+          sudo apt update
+          sudo apt install -y upx
+          make ${{ matrix.goos }}/${{ matrix.goarch }}/archive
 
-    - name: Create Release
-      id: create_release
-      uses: softprops/action-gh-release@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        name: Release ${{ github.ref_name }}
-        draft: false
-        prerelease: false
-        files: out/*
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          files: out/*
+
   krew:
     needs: build
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Update new version in krew-index
-      uses: rajatjindal/krew-release-bot@v0.0.46
+      - name: Update new version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # Build artifacts
 out/
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,3 +22,5 @@ archives:
 checksum:
   algorithm: sha256
   split: true
+changelog:
+  disable: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,16 @@
+project_name: kubectl-nsenter
+builds:
+  - env: [CGO_ENABLED=0]
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -X main.Version={{.Env.ARTIFACT_VERSION}}
+checksum:
+  algorithm: sha256
+  split: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,8 +15,7 @@ builds:
     ldflags:
       - -X main.Version={{.Env.ARTIFACT_VERSION}}
 archives:
-  - name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
-    wrap_in_directory: false
+  - wrap_in_directory: false
     files:
       - LICENSE
 checksum:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,3 +24,5 @@ checksum:
   split: true
 changelog:
   use: github-native
+release:
+  name_template: "Release {{.Tag}}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,8 @@
+version: 2
 project_name: kubectl-nsenter
 builds:
   - main: ./cmd/kubectl-nsenter
+    binary: kubectl-nsenter-{{.Os}}-{{.Arch}}
     env: [CGO_ENABLED=0]
     goos:
       - linux
@@ -12,7 +14,11 @@ builds:
       - -trimpath
     ldflags:
       - -X main.Version={{.Env.ARTIFACT_VERSION}}
-
+archives:
+  - name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
+    wrap_in_directory: false
+    files:
+      - LICENSE
 checksum:
   algorithm: sha256
   split: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,8 @@ builds:
     ldflags:
       - -X main.Version={{.Env.ARTIFACT_VERSION}}
 archives:
-  - wrap_in_directory: false
+  - name_template: "{{ .Binary }}"
+    wrap_in_directory: false
     files:
       - LICENSE
 checksum:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ builds:
       - -trimpath
     ldflags:
       - -X main.Version={{.Env.ARTIFACT_VERSION}}
+
 checksum:
   algorithm: sha256
   split: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,4 +23,4 @@ checksum:
   algorithm: sha256
   split: true
 changelog:
-  disable: true
+  use: github-native

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,7 @@
 project_name: kubectl-nsenter
 builds:
-  - env: [CGO_ENABLED=0]
+  - main: ./cmd/kubectl-nsenter
+    env: [CGO_ENABLED=0]
     goos:
       - linux
       - darwin

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/pabateman/kubectl-nsenter
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.24.3
 
 require (
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
- dependabot:
  - added config for GitHub actions;
- workflows:
  - reformatted files for better readability;
  - reconfigured setup-go action to match version specified in go.mod;
  - switched from build matrix to goreleaser;
  - removed installation of upx as it's not being used anyway;
  - removed unnecessary checks from release workflow as the same checks get executed during PR validation process;
- .gitignore:
  - added `dist/` to ignore goreleaser's builds;
- Go:
  - bumped version to 1.24.3.